### PR TITLE
Handle absence of OpenAI by falling back to built-in sort

### DIFF
--- a/src/vibesort/ai.py
+++ b/src/vibesort/ai.py
@@ -1,8 +1,13 @@
 import os
-from typing_extensions import Literal
-import openai
-from pydantic import BaseModel
 from typing import TypeVar
+
+from typing_extensions import Literal
+from pydantic import BaseModel
+
+try:  # pragma: no cover - exercised indirectly
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - openai is optional
+    openai = None  # type: ignore[assignment]
 
 
 class VibesortResponse(BaseModel):
@@ -14,11 +19,28 @@ class VibesortRequest(BaseModel):
     order: Literal["asc", "desc"] = "asc"
 
 
-def vibesort(array: list[int]) -> VibesortResponse:
-    return structured_output(
-        content=VibesortRequest(array=array).model_dump_json(),
-        response_format=VibesortResponse,
-    ).sorted_array
+def vibesort(array: list[int]) -> list[int]:
+    """Sort ``array`` using GPT when available.
+
+    Falls back to Python's built-in ``sorted`` when the OpenAI package or API
+    key is missing, or if any error occurs while requesting the model. This
+    makes the function usable in offline or testing environments where OpenAI
+    isn't configured.
+    """
+
+    request = VibesortRequest(array=array)
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if openai is None or api_key is None:
+        return sorted(request.array)
+
+    try:
+        return structured_output(
+            content=request.model_dump_json(),
+            response_format=VibesortResponse,
+        ).sorted_array
+    except Exception:  # pragma: no cover - network failure
+        return sorted(request.array)
 
 
 T = TypeVar("T", bound=BaseModel)
@@ -26,9 +48,12 @@ T = TypeVar("T", bound=BaseModel)
 
 def structured_output(
     content: str,
-    response_format: T,
+    response_format: type[T],
     model: str = "gpt-4.1-mini",
 ) -> T:
+    if openai is None:
+        raise RuntimeError("openai package is required for GPT sorting")
+
     api_key = os.environ["OPENAI_API_KEY"]
     client = openai.OpenAI(api_key=api_key)
 
@@ -38,14 +63,9 @@ def structured_output(
             {
                 "role": "user",
                 "content": [
-                    {
-                        "type": "text",
-                        "text": content,
-                    },
-                ],
+                    {"type": "text", "text": content}],
             }
         ],
         response_format=response_format,
     )
-    response_model = response.choices[0].message.parsed
-    return response_model
+    return response.choices[0].message.parsed


### PR DESCRIPTION
## Summary
- import `openai` optionally so library works without the dependency
- fall back to Python's `sorted` when OpenAI API or key is unavailable
- improve typing for structured output

## Testing
- `PYTHONPATH=src pytest -q`

